### PR TITLE
lsm.conf: provider status is unknown on restart. Refs #3427

### DIFF
--- a/nethserver-lsm.spec
+++ b/nethserver-lsm.spec
@@ -1,6 +1,6 @@
 Summary: NethServer Link Status Monitor configuration
 Name: nethserver-lsm
-Version: 1.1.1
+Version: 1.1.2
 Release: 1%{?dist}
 License: GPL
 URL: %{url_prefix}/%{name} 
@@ -36,6 +36,9 @@ echo "%doc COPYING" >> %{name}-%{version}-filelist
 %defattr(-,root,root)
 
 %changelog
+* Fri Nov 04 2016 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.1.2-1
+- lsm.conf: provider status is unknown on restart. Refs #3427
+
 * Thu Feb 18 2016 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.1.1-1
 - Latency monitoring in multiwan - Enhancement #3351
 

--- a/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
+++ b/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
@@ -15,10 +15,10 @@
         my $i = 1;
         foreach (split(',',$checkip)) {
             push(@members, "$name$i");
-            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n  status=1\n}\n";
+            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n}\n";
             $i++;
         }
-        $OUT .= "group {\n  name=$name\n  logic=0\n  status=1\n";
+        $OUT .= "group {\n  name=$name\n  logic=0\n";
         $OUT .= "  eventscript=/usr/libexec/nethserver/lsm-wan-link-update\n";
         if ( $notify eq 'enabled' ) {
             $OUT .= "  notifyscript=/usr/libexec/nethserver/lsm-wan-notify\n";

--- a/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
+++ b/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
@@ -7,15 +7,22 @@
     my $checkip = $firewall{'CheckIP'} || '8.8.8.8,208.67.222.222';
     my $notify = $firewall{'NotifyWan'} || 'disabled';
     foreach my $provider ( $ndb->get_all_by_prop('type' => 'provider') ) {
+        my $sourceip = '';
         my $name = $provider->key;
         my $status = $provider->prop('status') || 'disabled';
         next if ($status eq 'disabled');
         my $device = $provider->prop('interface') || next;
+        my $eth = $ndb->get($device) || next;
+        my $bootproto = $eth->prop('bootproto') || 'none';
+        if ($bootproto eq 'none') {
+            my $ip = $eth->prop('ipaddr') || next;
+            $sourceip = "  sourceip=$ip\n";
+        }
         my @members;
         my $i = 1;
         foreach (split(',',$checkip)) {
             push(@members, "$name$i");
-            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n}\n";
+            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n$sourceip}\n";
             $i++;
         }
         $OUT .= "group {\n  name=$name\n  logic=0\n";

--- a/root/usr/libexec/nethserver/lsm-wan-notify
+++ b/root/usr/libexec/nethserver/lsm-wan-notify
@@ -27,6 +27,11 @@ SRCIP=${14}
 PREVSTATE=${15}
 TIMESTAMP=${16}
 
+# avoid alerts on lsm restart
+if [ ${PREVSTATE} = 'unknown' ]; then
+    exit 0
+fi
+
 DATE=$(date --date=@${TIMESTAMP})
 
 from=`/sbin/e-smith/config getprop firewall NotifyWanFrom`


### PR DESCRIPTION
We will need this fix when we switch to shorewall-5.0.12
