### PR TITLE
lsm: forward port sourceip (#3431) and use checkip as connection name

### DIFF
--- a/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
+++ b/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
@@ -10,11 +10,9 @@
         my $name = $provider->key;
         my $device = $provider->prop('interface') || next;
         my @members;
-        my $i = 1;
         foreach (split(',',$checkip)) {
-            push(@members, "$name$i");
-            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n  status=1\n}\n";
-            $i++;
+            push(@members, "$name-$_");
+            $OUT .= "connection {\n  name=$name-$_\n  checkip=$_\n  device=$device\n  status=1\n}\n";
         }
         $OUT .= "group {\n  name=$name\n  logic=0\n  status=1\n";
         $OUT .= "  eventscript=/usr/libexec/nethserver/lsm-wan-link-update\n";

--- a/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
+++ b/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
@@ -7,14 +7,21 @@
     my $checkip = $firewall{'CheckIP'} || '8.8.8.8,208.67.222.222';
     my $notify = $firewall{'NotifyWan'} || 'disabled';
     foreach my $provider ( $ndb->get_all_by_prop('type' => 'provider') ) {
+        my $sourceip = '';
         my $name = $provider->key;
         my $device = $provider->prop('interface') || next;
+        my $eth = $ndb->get($device) || next;
+        my $bootproto = $eth->prop('bootproto') || 'none';
+        if ($bootproto eq 'none') {
+            my $ip = $eth->prop('ipaddr') || next;
+            $sourceip = "  sourceip=$ip\n";
+        }
         my @members;
         foreach (split(',',$checkip)) {
             push(@members, "$name-$_");
-            $OUT .= "connection {\n  name=$name-$_\n  checkip=$_\n  device=$device\n  status=1\n}\n";
+            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n$sourceip}\n";
         }
-        $OUT .= "group {\n  name=$name\n  logic=0\n  status=1\n";
+        $OUT .= "group {\n  name=$name\n  logic=0\n";
         $OUT .= "  eventscript=/usr/libexec/nethserver/lsm-wan-link-update\n";
         if ( $notify eq 'enabled' ) {
             $OUT .= "  notifyscript=/usr/libexec/nethserver/lsm-wan-notify\n";

--- a/root/usr/libexec/nethserver/lsm-wan-notify
+++ b/root/usr/libexec/nethserver/lsm-wan-notify
@@ -27,6 +27,11 @@ SRCIP=${14}
 PREVSTATE=${15}
 TIMESTAMP=${16}
 
+# avoid alerts on lsm restart
+if [ ${PREVSTATE} = 'unknown' ]; then
+    exit 0
+fi
+
 DATE=$(date --date=@${TIMESTAMP})
 
 from=`/sbin/e-smith/config getprop firewall NotifyWanFrom`


### PR DESCRIPTION
Forward port of fix for sourceip in lsm.con.
http://dev.nethserver.org/issues/3431

This PR improves readability of the collectd Table graphs about multi wan latency.
Now, graph labels use the name-N format, where N is a progressive number referring to the checkips the user chose (if the provider is called fastisp, graphs have names like fastisp1 and fastisp2).
With this patch, assuming checkip are 8.8.8.8 and 8.8.4.4, graphs will use fastisp_8.8.8.8 and fastisp_8.8.4.4.
