### PR TITLE
lsm.conf: use checkip as connection name

### DIFF
--- a/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
+++ b/root/etc/e-smith/templates/etc/lsm/lsm.conf/20providers
@@ -19,7 +19,7 @@
         my @members;
         foreach (split(',',$checkip)) {
             push(@members, "$name-$_");
-            $OUT .= "connection {\n  name=$name$i\n  checkip=$_\n  device=$device\n$sourceip}\n";
+            $OUT .= "connection {\n  name=$name-$_\n  checkip=$_\n  device=$device\n$sourceip}\n";
         }
         $OUT .= "group {\n  name=$name\n  logic=0\n";
         $OUT .= "  eventscript=/usr/libexec/nethserver/lsm-wan-link-update\n";


### PR DESCRIPTION
Missing fix for:
https://github.com/NethServer/nethserver-lsm/pull/3/commits/03fe66f909cbca07f7fad08d79fd9b58a3628f8a