### PR TITLE
Do not use the default NotifyWanTo

### DIFF
--- a/root/usr/libexec/nethserver/lsm-wan-notify
+++ b/root/usr/libexec/nethserver/lsm-wan-notify
@@ -39,7 +39,7 @@ NotifyWanTo=`/sbin/e-smith/config getprop firewall NotifyWanTo | tr ',' ' '`
 NotificationFrom=`/sbin/e-smith/config getprop root SenderAddress`
 NotificationTo=`/sbin/e-smith/config getprop root EmailAddress | tr ',' ' '`
 
-if [[ -n $NotifyWanTo ]]; then
+if [[ -n $NotifyWanTo && $NotifyWanTo != 'root@localhost' ]]; then
     to=${NotifyWanTo}
     from=${NotifyWanFrom}
 elif [[ -n $NotificationTo ]]; then


### PR DESCRIPTION
When a link is down we must not use the default value of NotifyWanTo, we will use it at the end of all conditions

https://github.com/NethServer/dev/issues/6497